### PR TITLE
perf: optimize flowOf(markdown) with lazy line sequence

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,7 @@ kotlin {
 
         jsMain {
             dependencies {
+                implementation(libs.xemantic.kotlin.core)
                 implementation(libs.xemantic.kotlin.js)
                 implementation(libs.markanywhere.parse)
                 implementation(libs.markanywhere.js)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ asm = "9.9.1"
 jetbrainsAnnotations = "26.0.2-1"
 
 xemanticKotlinTest = "1.17.3"
+xemanticKotlinCore = "0.6.4"
 xemanticKotlinJs = "0.1.0"
 markanywhere = "0.1.12"
 
@@ -25,6 +26,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotations" }
 xemantic-kotlin-test = { module = "com.xemantic.kotlin:xemantic-kotlin-test", version.ref = "xemanticKotlinTest" }
+xemantic-kotlin-core = { module = "com.xemantic.kotlin:xemantic-kotlin-core", version.ref = "xemanticKotlinCore" }
 xemantic-kotlin-js = { module = "com.xemantic.kotlin:xemantic-kotlin-js", version.ref = "xemanticKotlinJs" }
 markanywhere-parse = { module = "com.xemantic.markanywhere:markanywhere-parse", version.ref = "markanywhere" }
 markanywhere-js = { module = "com.xemantic.markanywhere:markanywhere-js", version.ref = "markanywhere" }

--- a/src/jsMain/kotlin/com/xemantic/markdown/editor/MarkdownViewModel.kt
+++ b/src/jsMain/kotlin/com/xemantic/markdown/editor/MarkdownViewModel.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 
 /**
@@ -78,7 +78,7 @@ fun main() {
         )
 
     val parsedMarkdown: Flow<Flow<SemanticEvent>> =
-        markdownText.map { markdown -> flowOf(markdown).parse(parser) }
+        markdownText.map { markdown -> markdown.lineSequence().asFlow().parse(parser) }
 
     fun onMarkdownChanged(text: String) {
         markdownText.value = text

--- a/src/jsMain/kotlin/com/xemantic/markdown/editor/MarkdownViewModel.kt
+++ b/src/jsMain/kotlin/com/xemantic/markdown/editor/MarkdownViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.xemantic.markdown.editor
 
+import com.xemantic.kotlin.core.text.lineFlow
 import com.xemantic.markanywhere.SemanticEvent
 import com.xemantic.markanywhere.parse.DefaultMarkanywhereParser
 import com.xemantic.markanywhere.parse.MarkanywhereParser
@@ -27,7 +28,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 
 /**
@@ -78,7 +78,7 @@ fun main() {
         )
 
     val parsedMarkdown: Flow<Flow<SemanticEvent>> =
-        markdownText.map { markdown -> markdown.lineSequence().asFlow().parse(parser) }
+        markdownText.map { markdown -> markdown.lineFlow().parse(parser) }
 
     fun onMarkdownChanged(text: String) {
         markdownText.value = text


### PR DESCRIPTION
Replace `flowOf(markdown)` with `markdown.lineSequence().asFlow()` for lazy line-by-line parsing.

Instead of wrapping the entire markdown document in a single-element flow, split it into a lazy flow of lines. This aligns with the `MarkanywhereParser` interface which accepts `Flow<String>` as streaming chunks, enabling the parser to process lines incrementally and reducing peak memory footprint.

Closes #15

Generated with [Claude Code](https://claude.ai/code)